### PR TITLE
Fix spacing in code/api, remove file '\' containing commit message

### DIFF
--- a/\
+++ b/\
@@ -1,9 +1,0 @@
-made line 6 of readme easier to understand
-# Please enter the commit message for your changes. Lines starting
-# with '#' will be ignored, and an empty message aborts the commit.
-# On branch master
-# Your branch is up-to-date with 'origin/master'.
-#
-# Changes to be committed:
-#	modified:   code/api/README.md
-#

--- a/code/api/app.py
+++ b/code/api/app.py
@@ -36,8 +36,8 @@ def json_blob():
 	"returnCountOnly":"false",
 	"f":"pjson",
 	"returnDistinctValues":"false"}
-   date = json.loads(dr.text(requests.get(dateurl, dparams=datepayload))) #Apparently, something's wrong with the parenthises on this line
-   return date
+    date = json.loads(dr.text(requests.get(dateurl, dparams=datepayload)))
+    return date
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', debug=False)


### PR DESCRIPTION
Python was complaining about indentation.